### PR TITLE
Fix featured song filepath issue + Move song list fo config file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ cachetools = "*"
 gtts = "*"
 lxml = "*"
 requests = "*"
+pyyaml = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b5eadab7e20196fc31d02578b24a4a5f4bd4e65e3dfb82d5ae409bd7683c539f"
+            "sha256": "fc638a287d7e9becfe81f915f2397c74f57b0feb59f9da9798a1179a2524cb28"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -176,6 +176,23 @@
                 "sha256:dcadf1593b5891ddb21df4ac943d720d9da22be2a686ad73621ca86d1f72dafe"
             ],
             "version": "==4.19.17"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
+                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
+                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
+                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
+                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
+                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
+                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
+                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
+                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
+                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
+                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+            ],
+            "index": "pypi",
+            "version": "==5.1.1"
         },
         "requests": {
             "hashes": [

--- a/only_otters/music_player/featured_songs.yml
+++ b/only_otters/music_player/featured_songs.yml
@@ -1,0 +1,17 @@
+
+songs:
+  
+  - img: earth_cover.png
+    audio: Lil Dicky - Earth.mp3
+  
+  - img: wonderful_world_cover.jpg
+    audio: Louis Armstrong - What a Wonderful World.mp3
+
+  - img: earth_song_cover.jpg
+    audio: Michael Jackson - Earth Song.mp3
+
+  - img: heal_world_cover.png
+    audio: Michael Jackson - Heal The World.mp3
+
+  - img: lovesong_cover.jpg
+    audio: Paul McCartney - Love Song To The Earth.mp3


### PR DESCRIPTION
> zebralt: I fixed it, just needed to force the absolute path
also, instead of converting pathlib objects to str all over the place, consider using os.fspath where it fits, like before passing them to Qt objects
https://docs.python.org/3/library/os.html#os.fspath
Still, seems weird that pyqt doesn't support pathib ... but outside of qt, we don't need to know whether they're strings or Path objects except for the functions that require us to explicitly translate
i refactored some code in featured_songs.py as well while I was there
put the song list in a config file
i think this is something to be done everytime we have constants like that in the code
this way we can update it easily without touching the code
takes a load off your brain
we could have the same for other images
[09:14] zebralt: also you had inverted img and audio in add_featured_song, so i put them in the right order
